### PR TITLE
Refresh SSO linking page UI and add local i18n resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 This project has been forked from the [creator's code](https://github.com/9p4/jellyfin-plugin-sso), with the intention of continuing to maintain it and add features. If you use it, please open discussions or issues so we can continue development as best as possible.
 
 ## About
+
 This plugin allows users to sign in through an SSO provider (such as Google, Microsoft, or your own provider). This enables one-click signin.
 
 https://user-images.githubusercontent.com/17993169/149681516-f93b43f5-fa5c-4c1f-a909-e5414878a864.mp4

--- a/SSO-Auth/Config/i18n/en-us.json
+++ b/SSO-Auth/Config/i18n/en-us.json
@@ -1,0 +1,24 @@
+{
+  "common": {
+    "Home": "Home",
+    "Help": "Help"
+  },
+  "linking": {
+    "PageTitle": "SSO Linking",
+    "AccountLinkingKicker": "Account linking",
+    "AccountLinkingTitle": "SSO Linking",
+    "AccountLinkingDescription": "Link this Jellyfin user to external OIDC or SAML identities, then remove stale links only after enabling delete mode.",
+    "LinkProviderTitle": "Link a provider",
+    "LinkProviderDescription": "Use Link account on a provider card to add a new identity.",
+    "SamlProviderDescription": "Identity providers using SAML assertions.",
+    "OidcProviderDescription": "Identity providers using OpenID Connect.",
+    "RemoveLinkedIdentitiesTitle": "Remove linked identities",
+    "RemoveLinkedIdentitiesDescription": "Select linked identities above, enable delete mode, then delete the selected links.",
+    "EnableDeleteMode": "Enable delete mode",
+    "DeleteSelected": "Delete Selected",
+    "LinkAccount": "Link account",
+    "LinkedIdentities": "Linked identities",
+    "NoIdentityLinked": "No identity linked to this provider.",
+    "NoProvidersConfigured": "No {0} providers are configured yet."
+  }
+}

--- a/SSO-Auth/Config/linking.html
+++ b/SSO-Auth/Config/linking.html
@@ -36,9 +36,19 @@
             class="sectionTitleContainer flex align-items-center sso-linking-header"
           >
             <div class="sso-linking-heading">
-              <p class="sso-kicker">Account linking</p>
-              <h2 class="sectionTitle sso-linking-title">SSO Linking</h2>
-              <p class="sso-linking-copy">
+              <p class="sso-kicker" data-i18n="linking.AccountLinkingKicker">
+                Account linking
+              </p>
+              <h2
+                class="sectionTitle sso-linking-title"
+                data-i18n="linking.AccountLinkingTitle"
+              >
+                SSO Linking
+              </h2>
+              <p
+                class="sso-linking-copy"
+                data-i18n="linking.AccountLinkingDescription"
+              >
                 Link this Jellyfin user to external OIDC or SAML identities,
                 then remove stale links only after enabling delete mode.
               </p>
@@ -49,7 +59,7 @@
                 style="display: none"
               >
                 <span class="material-icons home" aria-hidden="true"></span>
-                <span>Home</span>
+                <span data-i18n="common.Home">Home</span>
               </a>
               <a
                 is="emby-button"
@@ -59,7 +69,7 @@
                 href="https://github.com/k0lin/jellyfin-plugin-sso"
               >
                 <span class="material-icons help" aria-hidden="true"></span>
-                <span>Help</span>
+                <span data-i18n="common.Help">Help</span>
               </a>
             </div>
           </div>
@@ -67,8 +77,13 @@
           <section class="sso-linking-panel">
             <div class="sso-panel-heading">
               <div>
-                <h3 class="sectionTitle">Link a provider</h3>
-                <p class="sso-linking-copy">
+                <h3 class="sectionTitle" data-i18n="linking.LinkProviderTitle">
+                  Link a provider
+                </h3>
+                <p
+                  class="sso-linking-copy"
+                  data-i18n="linking.LinkProviderDescription"
+                >
                   Use Link account on a provider card to add a new identity.
                 </p>
               </div>
@@ -78,7 +93,9 @@
               <section class="sso-provider-section">
                 <div class="sso-provider-section-header">
                   <span class="sso-provider-badge">SAML</span>
-                  <p>Identity providers using SAML assertions.</p>
+                  <p data-i18n="linking.SamlProviderDescription">
+                    Identity providers using SAML assertions.
+                  </p>
                 </div>
                 <div
                   id="sso-provider-list-saml"
@@ -90,7 +107,9 @@
               <section class="sso-provider-section">
                 <div class="sso-provider-section-header">
                   <span class="sso-provider-badge">OIDC</span>
-                  <p>Identity providers using OpenID Connect.</p>
+                  <p data-i18n="linking.OidcProviderDescription">
+                    Identity providers using OpenID Connect.
+                  </p>
                 </div>
                 <div
                   id="sso-provider-list-oid"
@@ -103,8 +122,16 @@
 
           <section class="sso-danger-panel">
             <div>
-              <h3 class="sectionTitle">Remove linked identities</h3>
-              <p class="sso-linking-copy">
+              <h3
+                class="sectionTitle"
+                data-i18n="linking.RemoveLinkedIdentitiesTitle"
+              >
+                Remove linked identities
+              </h3>
+              <p
+                class="sso-linking-copy"
+                data-i18n="linking.RemoveLinkedIdentitiesDescription"
+              >
                 Select linked identities above, enable delete mode, then delete
                 the selected links.
               </p>
@@ -112,7 +139,12 @@
             <div class="sso-delete-actions">
               <label class="checkbox-wrapper sso-delete-toggle">
                 <input is="emby-checkbox" id="enable-delete" type="checkbox" />
-                <span class="checkbox-label">Enable delete mode</span>
+                <span
+                  class="checkbox-label"
+                  data-i18n="linking.EnableDeleteMode"
+                >
+                  Enable delete mode
+                </span>
               </label>
               <button
                 id="btn-delete-selected-links"
@@ -121,7 +153,7 @@
                 disabled="true"
               >
                 <span class="material-icons delete" aria-hidden="true"></span>
-                <span>Delete Selected</span>
+                <span data-i18n="linking.DeleteSelected">Delete Selected</span>
               </button>
             </div>
           </section>

--- a/SSO-Auth/Config/linking.html
+++ b/SSO-Auth/Config/linking.html
@@ -3,9 +3,10 @@
   <head>
     <!-- Polyfill styles that are missing when serving without dashboard -->
     <link rel="stylesheet" href="emby-restyle.css" />
+    <link rel="stylesheet" href="style.css" />
     <link id="theme-style" rel="stylesheet" />
     <script defer>
-      import("./ApiClient.js").then((clientModule) => {
+      import("./ApiClient.js").then(() => {
         import("./linking.js").then((renderer) => {
           const view = document.querySelector("#sso-config-page");
 
@@ -30,68 +31,100 @@
       data-controller="__plugin/SSO-Auth-linking.js"
     >
       <div data-role="content">
-        <div class="content-primary">
-          <div class="sectionTitleContainer flex align-items-center">
-            <a class="raised emby-button home" style="display: none">
-              <span class="material-icons home" aria-hidden="true"></span
-              ><span>Home</span>
-            </a>
-            <h2 class="sectionTitle">SSO Linking:</h2>
-            <a
-              is="emby-button"
-              class="raised button-alt headerHelpButton"
-              target="_blank"
-              href="https://github.com/k0lin/jellyfin-plugin-sso"
-              >${Help}</a
-            >
-          </div>
-          <p>
-            Use the
-            <span class="fab" aria-hidden="true">
-              <span class="material-icons add" aria-hidden="true"></span>
-            </span>
-            button to create a new link for the given provider.
-            <br />
-            You may remove existing links by selecting them and pressing the
-            "Delete" button.
-          </p>
-          <p>
-            See the
-            <a
-              is="emby-linkbutton"
-              href="https://github.com/k0lin/jellyfin-plugin-sso"
-              class="button-link"
-              >homepage</a
-            >
-            and
-            <a
-              is="emby-linkbutton"
-              href="https://github.com/k0lin/jellyfin-plugin-sso/issues"
-              class="button-link"
-              >issue tracker
-            </a>
-            for more information.
-          </p>
-          <label class="checkbox-wrapper">
-            <input is="emby-checkbox" id="enable-delete" type="checkbox" />
-            <span class="checkbox-label">Enable "Delete" button.</span>
-          </label>
-          <h1 class="sectionTitle">Link a provider</h1>
-          <div class="verticalSection" title="Link a provider">
-            <h2 class="sectionTitle">SAML</h2>
-            <div id="sso-provider-list-saml" data-id="saml"></div>
-            <h2 class="sectionTitle">OID</h2>
-            <div id="sso-provider-list-oid" data-id="oid"></div>
-          </div>
-          <button
-            id="btn-delete-selected-links"
-            type="button"
-            class="button-delete raised emby-button"
-            disabled="true"
+        <div class="content-primary sso-linking-shell">
+          <div
+            class="sectionTitleContainer flex align-items-center sso-linking-header"
           >
-            <span class="material-icons delete" aria-hidden="true"></span>
-            <span>Delete Selected</span>
-          </button>
+            <div class="sso-linking-heading">
+              <p class="sso-kicker">Account linking</p>
+              <h2 class="sectionTitle sso-linking-title">SSO Linking</h2>
+              <p class="sso-linking-copy">
+                Link this Jellyfin user to external OIDC or SAML identities,
+                then remove stale links only after enabling delete mode.
+              </p>
+            </div>
+            <div class="sso-header-actions">
+              <a
+                class="raised emby-button home sso-home-button"
+                style="display: none"
+              >
+                <span class="material-icons home" aria-hidden="true"></span>
+                <span>Home</span>
+              </a>
+              <a
+                is="emby-button"
+                class="raised emby-button button-alt sso-help-button"
+                target="_blank"
+                rel="noopener noreferrer"
+                href="https://github.com/k0lin/jellyfin-plugin-sso"
+              >
+                <span class="material-icons help" aria-hidden="true"></span>
+                <span>Help</span>
+              </a>
+            </div>
+          </div>
+
+          <section class="sso-linking-panel">
+            <div class="sso-panel-heading">
+              <div>
+                <h3 class="sectionTitle">Link a provider</h3>
+                <p class="sso-linking-copy">
+                  Use Link account on a provider card to add a new identity.
+                </p>
+              </div>
+            </div>
+
+            <div class="sso-provider-sections">
+              <section class="sso-provider-section">
+                <div class="sso-provider-section-header">
+                  <span class="sso-provider-badge">SAML</span>
+                  <p>Identity providers using SAML assertions.</p>
+                </div>
+                <div
+                  id="sso-provider-list-saml"
+                  class="sso-provider-grid"
+                  data-id="saml"
+                ></div>
+              </section>
+
+              <section class="sso-provider-section">
+                <div class="sso-provider-section-header">
+                  <span class="sso-provider-badge">OIDC</span>
+                  <p>Identity providers using OpenID Connect.</p>
+                </div>
+                <div
+                  id="sso-provider-list-oid"
+                  class="sso-provider-grid"
+                  data-id="oid"
+                ></div>
+              </section>
+            </div>
+          </section>
+
+          <section class="sso-danger-panel">
+            <div>
+              <h3 class="sectionTitle">Remove linked identities</h3>
+              <p class="sso-linking-copy">
+                Select linked identities above, enable delete mode, then delete
+                the selected links.
+              </p>
+            </div>
+            <div class="sso-delete-actions">
+              <label class="checkbox-wrapper sso-delete-toggle">
+                <input is="emby-checkbox" id="enable-delete" type="checkbox" />
+                <span class="checkbox-label">Enable delete mode</span>
+              </label>
+              <button
+                id="btn-delete-selected-links"
+                type="button"
+                class="button-delete raised emby-button"
+                disabled="true"
+              >
+                <span class="material-icons delete" aria-hidden="true"></span>
+                <span>Delete Selected</span>
+              </button>
+            </div>
+          </section>
         </div>
       </div>
     </div>

--- a/SSO-Auth/Config/linking.js
+++ b/SSO-Auth/Config/linking.js
@@ -1,3 +1,80 @@
+const normalizeLocale = (locale) =>
+  (locale || "en-us").toLowerCase().replace("_", "-");
+
+const ssoI18n = {
+  locale: "en-us",
+  strings: {},
+  supportedLocales: ["en-us"],
+
+  detectLocale() {
+    const browserLocales = navigator.languages?.length
+      ? navigator.languages
+      : [navigator.language];
+    const normalizedLocales = browserLocales.map(normalizeLocale);
+
+    this.locale =
+      normalizedLocales.find((locale) =>
+        this.supportedLocales.includes(locale),
+      ) ||
+      normalizedLocales
+        .map((locale) => locale.split("-")[0])
+        .map((language) =>
+          this.supportedLocales.find(
+            (supportedLocale) => supportedLocale.split("-")[0] === language,
+          ),
+        )
+        .find(Boolean) ||
+      "en-us";
+
+    document.documentElement.lang = this.locale;
+  },
+
+  async load() {
+    this.detectLocale();
+
+    const loadLocale = async (locale) => {
+      const response = await fetch(`./i18n/${locale}.json`);
+      if (!response.ok) {
+        throw new Error(`Unable to load locale ${locale}`);
+      }
+
+      return response.json();
+    };
+
+    try {
+      this.strings = await loadLocale(this.locale);
+    } catch (error) {
+      if (this.locale !== "en-us") {
+        this.locale = "en-us";
+        this.strings = await loadLocale(this.locale);
+      } else {
+        console.warn(error);
+        this.strings = {};
+      }
+    }
+
+    document.documentElement.lang = this.locale;
+    document.title = this.t("linking.PageTitle");
+  },
+
+  t(key, ...args) {
+    const value =
+      key.split(".").reduce((current, part) => current?.[part], this.strings) ||
+      key;
+
+    return args.reduce(
+      (text, arg, index) => text.replace(`{${index}}`, arg),
+      value,
+    );
+  },
+
+  localize(view) {
+    view.querySelectorAll("[data-i18n]").forEach((element) => {
+      element.textContent = this.t(element.getAttribute("data-i18n"));
+    });
+  },
+};
+
 const ssoConfigLinking = {
   pluginUniqueId: "505ce9d1-d916-42fa-86ca-673ef241d7df",
   loadProviders: (view) => {
@@ -33,7 +110,10 @@ const ssoConfigLinking = {
     if (!providers.length) {
       const emptyState = document.createElement("div");
       emptyState.classList.add("sso-empty-state");
-      emptyState.textContent = `No ${provider_mode.toUpperCase()} providers are configured yet.`;
+      emptyState.textContent = ssoI18n.t(
+        "linking.NoProvidersConfigured",
+        provider_mode.toUpperCase(),
+      );
       container.appendChild(emptyState);
       return;
     }
@@ -68,7 +148,7 @@ const ssoConfigLinking = {
         "sso-provider-add-link",
         "sso-provider",
       );
-      add_provider.innerHTML = `<span class="material-icons add" aria-hidden="true"></span><span>Link account</span>`;
+      add_provider.innerHTML = `<span class="material-icons add" aria-hidden="true"></span><span>${ssoI18n.t("linking.LinkAccount")}</span>`;
 
       add_provider.href = ApiClient.getUrl(
         `/SSO/${provider_mode}/p/${provider_name}?isLinking=true`,
@@ -126,14 +206,14 @@ const ssoConfigLinking = {
     if (!canonical_names.length) {
       const emptyState = document.createElement("p");
       emptyState.classList.add("sso-linked-empty");
-      emptyState.textContent = "No identity linked to this provider.";
+      emptyState.textContent = ssoI18n.t("linking.NoIdentityLinked");
       container.appendChild(emptyState);
       return;
     }
 
     const sectionTitle = document.createElement("p");
     sectionTitle.classList.add("sso-linked-title");
-    sectionTitle.textContent = "Linked identities";
+    sectionTitle.textContent = ssoI18n.t("linking.LinkedIdentities");
     container.appendChild(sectionTitle);
 
     const checkboxes = canonical_names.map((canonical_name) => {
@@ -203,7 +283,9 @@ const ssoConfigLinking = {
   },
 };
 
-export default function (view) {
+export default async function (view) {
+  await ssoI18n.load();
+  ssoI18n.localize(view);
   ssoConfigLinking.loadProviders(view);
 
   view.querySelector("#enable-delete").addEventListener("change", (e) => {

--- a/SSO-Auth/Config/linking.js
+++ b/SSO-Auth/Config/linking.js
@@ -30,39 +30,53 @@ const ssoConfigLinking = {
     });
   },
   loadProviderList: (container, providers, provider_mode) => {
+    if (!providers.length) {
+      const emptyState = document.createElement("div");
+      emptyState.classList.add("sso-empty-state");
+      emptyState.textContent = `No ${provider_mode.toUpperCase()} providers are configured yet.`;
+      container.appendChild(emptyState);
+      return;
+    }
+
     providers.forEach((provider_name) => {
       var provider_config = document.createElement("div");
       provider_config.classList.add("sso-provider-links-container");
       provider_config.setAttribute("data-id", provider_name);
 
-      provider_config.innerHTML = `
-      <label
-        class="inputLabel inputLabelUnfocused sso-provider-link-title"
-      >${provider_name}
-      </label>
-      <a
-        class="fab emby-button sso-provider-add-link"
-      >
-        <span class="material-icons add" aria-hidden="true"></span>
-      </a>
-      <div
-        class="sso-provider-existing-links-container"
-        data-provider="${provider_name}"
-      ></div>
-      `;
-      var add_provider = provider_config.querySelector(
-        ".sso-provider-add-link",
-      );
+      const heading = document.createElement("div");
+      heading.classList.add("sso-provider-card-heading");
 
-      //const provider_name_css = ssoConfigLinking.safeCSSId(provider_name);
-      //provider_link.id = "sso-provider-" + provider_name_css;
-      //provider_link.classList.add("sso-provider-" + provider_name_css);
-      add_provider.classList.add("sso-provider");
+      const title = document.createElement("div");
+      title.classList.add("sso-provider-link-title");
+      title.textContent = provider_name;
+
+      const mode = document.createElement("span");
+      mode.classList.add("sso-provider-mode");
+      mode.textContent = provider_mode.toUpperCase();
+
+      heading.appendChild(title);
+      heading.appendChild(mode);
+
+      const linkContainer = document.createElement("div");
+      linkContainer.classList.add("sso-provider-existing-links-container");
+      linkContainer.setAttribute("data-provider", provider_name);
+
+      const add_provider = document.createElement("a");
+      add_provider.classList.add(
+        "raised",
+        "emby-button",
+        "sso-provider-add-link",
+        "sso-provider",
+      );
+      add_provider.innerHTML = `<span class="material-icons add" aria-hidden="true"></span><span>Link account</span>`;
 
       add_provider.href = ApiClient.getUrl(
         `/SSO/${provider_mode}/p/${provider_name}?isLinking=true`,
       );
 
+      provider_config.appendChild(heading);
+      provider_config.appendChild(linkContainer);
+      provider_config.appendChild(add_provider);
       container.appendChild(provider_config);
     });
 
@@ -80,8 +94,12 @@ const ssoConfigLinking = {
           console.log({ provider_map, currentUserId });
 
           Object.keys(provider_map).forEach((provider_name) => {
-            const provider_container = container.querySelector(
-              `.sso-provider-existing-links-container[data-provider="${provider_name}"]`,
+            const provider_container = [
+              ...container.querySelectorAll(
+                ".sso-provider-existing-links-container",
+              ),
+            ].find(
+              (elem) => elem.getAttribute("data-provider") === provider_name,
             );
             ssoConfigLinking.populateExistingLinks(
               provider_container,
@@ -101,25 +119,40 @@ const ssoConfigLinking = {
     provider_name,
     canonical_names,
   ) => {
-    container
-      .querySelectorAll(".sso-provider-link-checkbox-wrapper")
-      .forEach((e) => e.remove());
+    if (!container) return;
+
+    container.replaceChildren();
+
+    if (!canonical_names.length) {
+      const emptyState = document.createElement("p");
+      emptyState.classList.add("sso-linked-empty");
+      emptyState.textContent = "No identity linked to this provider.";
+      container.appendChild(emptyState);
+      return;
+    }
+
+    const sectionTitle = document.createElement("p");
+    sectionTitle.classList.add("sso-linked-title");
+    sectionTitle.textContent = "Linked identities";
+    container.appendChild(sectionTitle);
 
     const checkboxes = canonical_names.map((canonical_name) => {
       var out = document.createElement("label");
       out.classList.add("sso-provider-link-checkbox-wrapper");
-      out.classList.add("checkbox-wrapper");
-      out.innerHTML = `
-        <input
-          is="emby-checkbox"
-          class="sso-link-checkbox"
-          data-id="${canonical_name}"
-          data-mode="${provider_mode}"
-          data-provider="${provider_name}"
-          type="checkbox"
-        />
-        <span class="checkbox-label">${canonical_name}</span>
-      `;
+
+      const input = document.createElement("input");
+      input.classList.add("sso-link-checkbox");
+      input.setAttribute("data-id", canonical_name);
+      input.setAttribute("data-mode", provider_mode);
+      input.setAttribute("data-provider", provider_name);
+      input.type = "checkbox";
+
+      const label = document.createElement("span");
+      label.classList.add("sso-provider-link-checkbox-text");
+      label.textContent = canonical_name;
+
+      out.appendChild(input);
+      out.appendChild(label);
       return out;
     });
 

--- a/SSO-Auth/Config/style.css
+++ b/SSO-Auth/Config/style.css
@@ -60,3 +60,254 @@
 .sso-role-mapping-input-label {
   padding-left: 0.5em;
 }
+
+.sso-linking-shell {
+  box-sizing: border-box;
+  margin: 0 auto;
+  max-width: 58rem;
+  padding-bottom: 5rem !important;
+}
+
+.sso-linking-panel,
+.sso-danger-panel {
+  border-top: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.sso-kicker {
+  color: #00a4dc;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin: 0 0 0.45rem;
+  text-transform: uppercase;
+}
+
+.sso-linking-header {
+  gap: 1rem;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.sso-linking-heading {
+  min-width: 0;
+}
+
+.sso-linking-title {
+  letter-spacing: -0.02em;
+  margin: 0;
+}
+
+.sso-linking-copy {
+  color: rgba(255, 255, 255, 0.72);
+  line-height: 1.55;
+  margin: 0.5rem 0 0;
+  max-width: 46rem;
+}
+
+.sso-home-button {
+  align-self: flex-start;
+  white-space: nowrap;
+}
+
+.sso-header-actions {
+  align-items: flex-start;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  justify-content: flex-end;
+}
+
+.sso-help-button {
+  align-items: center;
+  background: rgba(0, 164, 220, 0.14) !important;
+  border: 1px solid rgba(125, 211, 252, 0.35);
+  color: #d8f3ff !important;
+  display: inline-flex;
+  gap: 0.45rem;
+  margin: 0;
+  white-space: nowrap;
+}
+
+.sso-help-button:hover {
+  background: rgba(0, 164, 220, 0.24) !important;
+}
+
+.sso-linking-panel,
+.sso-danger-panel {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+}
+
+.sso-panel-heading,
+.sso-danger-panel {
+  align-items: flex-start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.sso-panel-heading .sectionTitle,
+.sso-danger-panel .sectionTitle {
+  margin: 0;
+}
+
+.sso-provider-sections {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1.25rem;
+}
+
+.sso-provider-section {
+  margin-top: 1rem;
+}
+
+.sso-provider-section-header {
+  align-items: center;
+  display: flex;
+  gap: 0.85rem;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.sso-provider-section-header p {
+  color: rgba(255, 255, 255, 0.64);
+  margin: 0;
+  text-align: right;
+}
+
+.sso-provider-badge,
+.sso-provider-mode {
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 0.38rem 0.62rem;
+  text-transform: uppercase;
+}
+
+.sso-provider-badge {
+  background: rgba(0, 164, 220, 0.18);
+  color: #7dd3fc;
+}
+
+.sso-provider-grid {
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+.sso-provider-links-container,
+.sso-empty-state {
+  background: rgba(255, 255, 255, 0.045);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.25rem;
+  padding: 1rem;
+}
+
+.sso-provider-links-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  min-height: 10rem;
+}
+
+.sso-provider-card-heading {
+  align-items: center;
+  display: flex;
+  gap: 0.7rem;
+  justify-content: space-between;
+}
+
+.sso-provider-link-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.sso-provider-mode {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.sso-provider-existing-links-container {
+  flex: 1;
+}
+
+.sso-linked-title {
+  color: rgba(255, 255, 255, 0.52);
+  font-size: 0.82rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem;
+  text-transform: uppercase;
+}
+
+.sso-linked-empty,
+.sso-empty-state {
+  color: rgba(255, 255, 255, 0.58);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.sso-provider-link-checkbox-wrapper {
+  align-items: center;
+  background: rgba(0, 0, 0, 0.16);
+  border-radius: 0.25rem;
+  cursor: pointer;
+  display: flex;
+  gap: 0.55rem;
+  margin-top: 0.5rem;
+  padding: 0.55rem 0.65rem;
+}
+
+.sso-provider-link-checkbox-wrapper .sso-link-checkbox {
+  accent-color: #2196f3;
+  flex: 0 0 auto;
+  height: 1.15rem;
+  margin: 0;
+  width: 1.15rem;
+}
+
+.sso-provider-link-checkbox-text {
+  font-size: 0.95rem;
+  line-height: 1.35;
+  margin-bottom: 0;
+  overflow-wrap: anywhere;
+  min-width: 0;
+}
+
+.sso-provider-add-link {
+  justify-content: center;
+  margin: 0;
+}
+
+.sso-delete-actions {
+  align-items: flex-end;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.sso-delete-toggle .checkbox-label {
+  font-size: 1rem;
+  margin-bottom: 0;
+}
+
+@media (max-width: 46rem) {
+  .sso-linking-header,
+  .sso-header-actions,
+  .sso-panel-heading,
+  .sso-danger-panel,
+  .sso-provider-section-header,
+  .sso-delete-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .sso-provider-section-header p {
+    text-align: left;
+  }
+
+  .sso-provider-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/SSO-Auth/SSO-Auth.csproj
+++ b/SSO-Auth/SSO-Auth.csproj
@@ -14,6 +14,7 @@
     <None Remove="Config\config.js" />
     <None Remove="Config\style.css" />
     <None Remove="Config\linking.html" />
+    <None Remove="Config\i18n\en-us.json" />
     <None Remove="Views\apiClient.js" />
     <None Remove="Views\jellyfin-apiClient.esm.min.js" />
     <None Remove="Views\emby-restyle.css" />
@@ -22,6 +23,7 @@
     <EmbeddedResource Include="Config\style.css" />
     <EmbeddedResource Include="Config\linking.html" />
     <EmbeddedResource Include="Config\linking.js" />
+    <EmbeddedResource Include="Config\i18n\en-us.json" />
     <EmbeddedResource Include="Views\apiClient.js" />
     <EmbeddedResource Include="Views\jellyfin-apiClient.esm.min.js" />
     <EmbeddedResource Include="Views\emby-restyle.css" />

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -100,6 +100,11 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
             },
             new PluginPageInfo
             {
+                Name = "i18n/en-us.json",
+                EmbeddedResourcePath = $"{GetType().Namespace}.Config.i18n.en-us.json"
+            },
+            new PluginPageInfo
+            {
                 Name = "ApiClient.js",
                 EmbeddedResourcePath = $"{GetType().Namespace}.Views.apiClient.js"
             },

--- a/SSO-Auth/Views/SSOViewsController.cs
+++ b/SSO-Auth/Views/SSOViewsController.cs
@@ -78,7 +78,7 @@ public class SSOViewsController : ControllerBase
     /// </summary>
     /// <param name="viewName">The name of the view / asset to fetch.</param>
     /// <returns>The html view with the specified name.</returns>
-    [HttpGet("{viewName}")]
+    [HttpGet("{**viewName}")]
     public ActionResult GetView([FromRoute] string viewName)
     {
         return ServeView(viewName);


### PR DESCRIPTION
## Summary

- Redesign the `/SSOViews/linking` page with provider cards, clearer linked identity management, and responsive layout styles.
- Improve the Help/Home header actions and load the plugin stylesheet from the standalone linking view.
- Add a local i18n foundation for the linking page using embedded per-locale JSON files.

## Details

- Adds `SSO-Auth/Config/i18n/en-us.json` with namespaced translation keys under `common` and `linking`.
- Updates static linking page text to use `data-i18n` keys and dynamic JavaScript-generated text to use the same resolver.
- Extends `SSOViewsController` to serve nested embedded resources, allowing paths like `/SSOViews/i18n/en-us.json`.
- Registers the new i18n JSON file as an embedded resource in the plugin project and `SSOPlugin` view list.