### PR TITLE
modernize CI tooling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,11 @@ on:
         default: "net9.0"
         description: "The .NET target to set for JPRM"
         type: string
+      ref:
+        required: false
+        default: ""
+        description: "The git ref to checkout for the build"
+        type: string
 
 jobs:
   build:
@@ -20,6 +25,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
         with:
           dotnet-version: "${{ inputs.dotnet-version }}"
 
@@ -31,7 +31,7 @@ jobs:
           dotnet-target: "${{ inputs.dotnet-target }}"
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag=v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build-artifact
           retention-days: 30

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,24 +2,27 @@ name: .NET
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 9.0.x
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --no-restore --warnaserror
-    - name: Test
-      run: dotnet test --no-build --verbosity normal
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        with:
+          dotnet-version: 9.0.x
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore --warnaserror
+      - name: Test
+        run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -2,22 +2,25 @@ name: Prettier Lint
 
 on:
   push:
-    branches: [ main ]
+    branches: [main, dev]
   pull_request:
-    branches: [ main ]
-
+    branches: [main]
 
 jobs:
   prettier:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
-          # Make sure the actual branch is checked out when running on pull requests
-          ref: ${{ github.head_ref }}
-      - name: Prettify code
-        uses: creyD/prettier_action@v4.3
-        with:
-          dry: True
-          prettier_options: '--check **/*.{js,html,md,css,scss}'
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check formatting
+        run: npm run format:check

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -6,12 +6,16 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   prettier:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -42,6 +42,27 @@ jobs:
           path: .
           dotnet-target: "net9.0"
           output: _dist
+      - name: Upload Artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nightly-build-artifact
+          retention-days: 30
+          if-no-files-found: error
+          path: |
+            _dist/*
+            build.yaml
+
+  upload:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    needs:
+      - build
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: nightly-build-artifact
       - name: Prepare GitHub Release assets
         run: |-
           pushd _dist
@@ -65,6 +86,14 @@ jobs:
             Nightly build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  generate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    needs:
+      - upload
+    steps:
       - name: Publish Plugin Manifest
         uses: Kevinjil/jellyfin-plugin-repo-action@a7832ecc44c6b1a45d531970f6647b8682b005b8
         with:

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -2,56 +2,59 @@ name: Publish Nightly
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      
+
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 9.0.x
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Build Dotnet
-      run: dotnet build --no-restore --warnaserror
-    - name: "Flag as nightly in build.yaml"
-      uses: fjogeleit/yaml-update-action@v0.10.0
-      with:
-        valueFile: 'build.yaml'
-        propertyPath: 'version'
-        value: "0.0.0.9000"
-        commitChange: false
-        updateFile: true
-    - name: "JPRM: Build"
-      id: jrpm
-      uses: oddstr13/jellyfin-plugin-repository-manager@9497a0a499416cc572ed2e07a391d9f943a37b4d # v1.1.1
-      with:
-        version: "0.0.0.9000"
-        verbosity: debug
-        path: .
-        dotnet-target: "net9.0"
-        output: _dist
-    - name: Prepare GitHub Release assets
-      run: |-
-        pushd _dist
-        for file in ./*.zip; do
-          md5sum ${file#./} >> ${file%.*}.md5
-          sha256sum ${file#./} >> ${file%.*}.sha256
-        done
-        ls -l
-        popd
-    - name: Publish output artifacts
-      id: publish-assets
-      uses: softprops/action-gh-release@50195ba7f6f93d1ac97ba8332a178e008ad176aa
-      with:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        with:
+          dotnet-version: 9.0.x
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build Dotnet
+        run: dotnet build --no-restore --warnaserror
+      - name: "Flag as nightly in build.yaml"
+        uses: fjogeleit/yaml-update-action@v0.10.0
+        with:
+          valueFile: "build.yaml"
+          propertyPath: "version"
+          value: "0.0.0.9000"
+          commitChange: false
+          updateFile: true
+      - name: "JPRM: Build"
+        id: jrpm
+        uses: oddstr13/jellyfin-plugin-repository-manager@9497a0a499416cc572ed2e07a391d9f943a37b4d # v1.1.1
+        with:
+          version: "0.0.0.9000"
+          verbosity: debug
+          path: .
+          dotnet-target: "net9.0"
+          output: _dist
+      - name: Prepare GitHub Release assets
+        run: |-
+          pushd _dist
+          for file in ./*.zip; do
+            md5sum ${file#./} >> ${file%.*}.md5
+            sha256sum ${file#./} >> ${file%.*}.sha256
+          done
+          ls -l
+          popd
+      - name: Publish output artifacts
+        id: publish-assets
+        uses: softprops/action-gh-release@50195ba7f6f93d1ac97ba8332a178e008ad176aa
+        with:
           prerelease: false
           fail_on_unmatched_files: true
           tag_name: nightly
@@ -60,14 +63,13 @@ jobs:
             build.yaml
           body: |
             Nightly build
-      env:
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Publish Plugin Manifest
-      uses: Kevinjil/jellyfin-plugin-repo-action@a7832ecc44c6b1a45d531970f6647b8682b005b8
-      with:
-        ignorePrereleases: true
-        githubToken: ${{ secrets.GITHUB_TOKEN }}
-        repository: ${{ github.repository }}
-        pagesBranch: manifest-release
-        pagesFile: manifest.json
-
+      - name: Publish Plugin Manifest
+        uses: Kevinjil/jellyfin-plugin-repo-action@a7832ecc44c6b1a45d531970f6647b8682b005b8
+        with:
+          ignorePrereleases: true
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          pagesBranch: manifest-release
+          pagesFile: manifest.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,52 +6,56 @@ on:
       - released
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     uses: ./.github/workflows/build.yml
     with:
       dotnet-version: "9.0.*"
-      dotnet-target:  "net9.0"
+      dotnet-target: "net9.0"
   upload:
     runs-on: ubuntu-latest
     permissions:
       contents: write
     needs:
-    - build
+      - build
     steps:
-    - name: Download Artifact
-      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
-      with:
-        name: build-artifact
-    - name: Prepare GitHub Release assets
-      run: |-
-        for file in ./*; do
-          md5sum ${file#./} >> ${file%.*}.md5
-          sha256sum ${file#./} >> ${file%.*}.sha256
-        done
-        ls -l
-    - name: Publish output artifacts
-      id: publish-assets
-      uses: softprops/action-gh-release@50195ba7f6f93d1ac97ba8332a178e008ad176aa
-      with:
+      - name: Download Artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: build-artifact
+      - name: Prepare GitHub Release assets
+        run: |-
+          for file in ./*; do
+            md5sum ${file#./} >> ${file%.*}.md5
+            sha256sum ${file#./} >> ${file%.*}.sha256
+          done
+          ls -l
+      - name: Publish output artifacts
+        id: publish-assets
+        uses: softprops/action-gh-release@50195ba7f6f93d1ac97ba8332a178e008ad176aa
+        with:
           prerelease: false
           fail_on_unmatched_files: true
-          tag_name:  ${{ github.event.release.tag_name }}
+          tag_name: ${{ github.event.release.tag_name }}
           files: ./*
-      env:
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   generate:
     runs-on: ubuntu-latest
     permissions:
       contents: write
     needs:
-    - upload
+      - upload
     steps:
-    - name: Publish Plugin Manifest
-      uses: Kevinjil/jellyfin-plugin-repo-action@a7832ecc44c6b1a45d531970f6647b8682b005b8
-      with:
-        ignorePrereleases: true
-        githubToken: ${{ secrets.GITHUB_TOKEN }}
-        repository: ${{ github.repository }}
-        pagesBranch: manifest-release
-        pagesFile: manifest.json
+      - name: Publish Plugin Manifest
+        uses: Kevinjil/jellyfin-plugin-repo-action@a7832ecc44c6b1a45d531970f6647b8682b005b8
+        with:
+          ignorePrereleases: true
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          pagesBranch: manifest-release
+          pagesFile: manifest.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,11 @@ on:
     types:
       - released
   workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Release tag to publish assets to"
+        required: true
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,6 +21,7 @@ jobs:
     with:
       dotnet-version: "9.0.*"
       dotnet-target: "net9.0"
+      ref: ${{ github.event.release.tag_name || inputs.tag_name }}
   upload:
     runs-on: ubuntu-latest
     permissions:
@@ -34,13 +40,26 @@ jobs:
             sha256sum ${file#./} >> ${file%.*}.sha256
           done
           ls -l
-      - name: Publish output artifacts
-        id: publish-assets
+      - name: Publish output artifacts from release event
+        if: github.event_name == 'release'
+        id: publish-assets-release
         uses: softprops/action-gh-release@50195ba7f6f93d1ac97ba8332a178e008ad176aa
         with:
           prerelease: false
           fail_on_unmatched_files: true
           tag_name: ${{ github.event.release.tag_name }}
+          files: ./*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish output artifacts from manual dispatch
+        if: github.event_name == 'workflow_dispatch'
+        id: publish-assets-dispatch
+        uses: softprops/action-gh-release@50195ba7f6f93d1ac97ba8332a178e008ad176aa
+        with:
+          prerelease: false
+          fail_on_unmatched_files: true
+          tag_name: ${{ inputs.tag_name }}
           files: ./*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,6 +198,8 @@ We format all C# code according to the .NET formatter. Run `dotnet build .` and 
 
 We use [Prettier](https://prettier.io) to format these files.
 
+Run `npm ci` once to install the pinned formatter, then use `npm run format` to format files or `npm run format:check` to verify formatting without writing changes.
+
 <!-- TODO
 
 -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "jellyfin-plugin-sso",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "prettier": "3.8.4"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "scripts": {
+    "format": "prettier --write \"**/*.{js,html,md,css,scss}\"",
+    "format:check": "prettier --check \"**/*.{js,html,md,css,scss}\""
+  },
+  "devDependencies": {
+    "prettier": "3.8.4"
+  }
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(chore)",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "dependencyDashboard": true,
+  "automerge": false,
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "schedule": ["before 6am on monday"],
+  "packageRules": [
+    {
+      "description": "Group Jellyfin host packages",
+      "matchPackageNames": ["Jellyfin.Controller", "Jellyfin.Model"],
+      "groupName": "jellyfin packages"
+    },
+    {
+      "description": "Require manual approval for major updates",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Require manual approval for security-sensitive OIDC updates",
+      "matchPackageNames": ["Duende.IdentityModel.OidcClient"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Group GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions"
+    },
+    {
+      "description": "Group analyzer packages",
+      "matchPackageNames": [
+        "SerilogAnalyzer",
+        "StyleCop.Analyzers",
+        "SmartAnalyzers.MultithreadingAnalyzer"
+      ],
+      "groupName": "dotnet analyzers"
+    }
+  ]
+}


### PR DESCRIPTION
### CI and workflow hardening

- Pin official GitHub Actions to exact commit SHAs.
- Modernize checkout/setup-dotnet/upload/download artifact actions.
- Add concurrency controls to CI/release workflows.
- Add least-privilege permissions:
  - build jobs use `contents: read`
  - release/manifest jobs keep `contents: write`
- Split nightly release into separate build/upload/manifest jobs so write permissions are only used where needed.
- Add manual release publish support via `workflow_dispatch.tag_name`.
- Ensure manual publish builds the exact tag that is being published.

### Tooling

- Add pinned Prettier tooling through `package.json` and `package-lock.json`.
- Add npm scripts:
  - `npm run format`
  - `npm run format:check`
- Update Prettier workflow to use `npm ci` and local scripts.

### Renovate

- Add conservative Renovate configuration.
- Disable automerge.
- Enable Dependency Dashboard.
- Group Jellyfin packages, GitHub Actions, and analyzer updates.
- Require manual approval for major updates and OIDC-sensitive dependency updates.
