### PR TITLE
fix: seal password-less SSO-linked accounts against empty-password login

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,22 @@ This is 100% alpha software! PRs are welcome to improve the code.
 
 This is my first time writing C# so please take all of the code written here with a grain of salt. This program should be reasonably secure since it validates all information passed from the client with either a certificate or a secret internal state.
 
+### Password-less SSO accounts
+
+Jellyfin accepts the **empty password** on the ordinary login form for any account that has no stored password, so an account this plugin manages would be reachable without the identity provider until something writes one. The plugin closes that door in three places:
+
+- **At provisioning**: every account created by an SSO login is routed at the plugin and given a random, unguessable password (64 bytes from the OS CSPRNG, hashed through Jellyfin's own crypto provider) before anything else touches it. If that write fails, the half-created account is removed again, so a failed login cannot leave a password-less account behind. Nothing is meant to know or display that password; its only job is to keep the manual login form closed.
+- **At login**: the same seal runs during an SSO login, before the session is created, so an account that only became SSO-linked at this login — an existing local account signed in by name — is closed immediately rather than at the next restart.
+- **At start-up**: a one-shot pass walks every canonical link in every provider (OID and SAML), finds linked accounts that still hold no stored password — accounts provisioned by plugin versions that never persisted one, or existing accounts an SSO identity was linked to by name or through the self-service linking page — and seals each with the same kind of unguessable password. The pass never changes login routing, never overwrites a password that is already set, and is idempotent, so it runs on every boot and does nothing once every linked account holds a password.
+
+If the start-up pass seals anything, Jellyfin's log carries one line you can filter for:
+
+```text
+[SSO Audit] Sealed 1 SSO-linked account(s) that had no stored password: ...
+```
+
+The line reports only a count, never which accounts, because those accounts were by definition reachable by anybody on the network. The login-time seal logs a similar line, also without an account name. If a sealed account's owner was signing in by leaving the password box empty, that stops working: they should sign in through the identity provider, or an administrator can set them a real password.
+
 ## Installing
 
 Add the package repo [https://raw.githubusercontent.com/k0lin/jellyfin-plugin-sso/manifest-release/manifest.json](https://raw.githubusercontent.com/k0lin/jellyfin-plugin-sso/manifest-release/manifest.json) to your Jellyfin plugin repositories.

--- a/SSO-Auth.Tests/Api/PasswordlessAccountSealerTests.cs
+++ b/SSO-Auth.Tests/Api/PasswordlessAccountSealerTests.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using MediaBrowser.Controller.Library;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests.Api;
+
+public class PasswordlessAccountSealerTests
+{
+    private readonly IUserManager _users = Substitute.For<IUserManager>();
+    private readonly RecordingCryptoProvider _crypto = new();
+    private readonly CapturingLogger _logger = new();
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task SealAsync_SealsAnAccountWithoutAStoredPassword(string? storedPassword)
+    {
+        var alice = TestModel.NewUser("alice", storedPassword);
+
+        var sealedNow = await PasswordlessAccountSealer.SealAsync(alice, _users, _crypto);
+
+        Assert.True(sealedNow);
+        Assert.Equal(RecordingCryptoProvider.HashOf(_crypto.HashedPasswords[0]), alice.Password);
+        Assert.Equal(TestModel.DefaultProvider, alice.AuthenticationProviderId);
+        await _users.Received(1).UpdateUserAsync(alice);
+    }
+
+    [Fact]
+    public async Task SealAsync_KeepsAnExistingPassword()
+    {
+        var alice = TestModel.NewUser("alice", "$PBKDF2$AB");
+
+        var sealedNow = await PasswordlessAccountSealer.SealAsync(alice, _users, _crypto);
+
+        Assert.False(sealedNow);
+        Assert.Equal("$PBKDF2$AB", alice.Password);
+        await _users.DidNotReceiveWithAnyArgs().UpdateUserAsync(Arg.Any<User>());
+        Assert.Empty(_crypto.HashedPasswords);
+    }
+
+    [Fact]
+    public async Task SealAsync_ThrowsWhenAnyDependencyIsNull()
+    {
+        var alice = TestModel.NewUser("alice");
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => PasswordlessAccountSealer.SealAsync(null!, _users, _crypto));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => PasswordlessAccountSealer.SealAsync(alice, null!, _crypto));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => PasswordlessAccountSealer.SealAsync(alice, _users, null!));
+    }
+
+    [Fact]
+    public void PasswordlessAccountSealedAtLogin_WhenWarningLevelIsDisabled_WritesNothing()
+    {
+        SsoAudit.PasswordlessAccountSealedAtLogin(new SilentLogger());
+    }
+
+    [Fact]
+    public async Task SealNewAccountAsync_MintsAndPersistsWithoutDeleting()
+    {
+        var alice = TestModel.NewUser("alice");
+
+        await PasswordlessAccountSealer.SealNewAccountAsync(alice, _users, _crypto, _logger);
+
+        Assert.Equal(RecordingCryptoProvider.HashOf(_crypto.HashedPasswords[0]), alice.Password);
+        await _users.Received(1).UpdateUserAsync(alice);
+        await _users.DidNotReceiveWithAnyArgs().DeleteUserAsync(Arg.Any<Guid>());
+        Assert.Empty(_logger.Entries);
+    }
+
+    [Fact]
+    public async Task SealNewAccountAsync_RemovesTheAccountAgainWhenThePersistFails()
+    {
+        var alice = TestModel.NewUser("alice");
+        _users
+            .When(userManager => userManager.UpdateUserAsync(alice))
+            .Throw(new InvalidOperationException("persist failed"));
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => PasswordlessAccountSealer.SealNewAccountAsync(alice, _users, _crypto, _logger));
+
+        Assert.Equal("persist failed", thrown.Message);
+        await _users.Received(1).DeleteUserAsync(alice.Id);
+        Assert.Empty(_logger.Entries);
+    }
+
+    [Fact]
+    public async Task SealNewAccountAsync_WhenTheDeleteAlsoFails_LogsTheAccountAndRethrows()
+    {
+        var alice = TestModel.NewUser("alice");
+        var persistFailure = new InvalidOperationException("persist failed");
+        _users
+            .When(userManager => userManager.UpdateUserAsync(alice))
+            .Throw(persistFailure);
+        _users
+            .When(userManager => userManager.DeleteUserAsync(alice.Id))
+            .Throw(new InvalidOperationException("delete failed too"));
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => PasswordlessAccountSealer.SealNewAccountAsync(alice, _users, _crypto, _logger));
+
+        Assert.Same(persistFailure, thrown);
+        var failure = Assert.Single(_logger.Entries);
+        Assert.Contains("[Error]", failure);
+        Assert.Contains("alice", failure);
+        Assert.Contains("accepts an empty password until one is set", failure);
+    }
+}

--- a/SSO-Auth.Tests/Api/PasswordlessLinkedAccountSweepServiceTests.cs
+++ b/SSO-Auth.Tests/Api/PasswordlessLinkedAccountSweepServiceTests.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Serialization;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests.Api;
+
+public class PasswordlessLinkedAccountSweepServiceTests : IDisposable
+{
+    private readonly IUserManager _users = Substitute.For<IUserManager>();
+    private readonly RecordingCryptoProvider _crypto = new();
+    private readonly TypedCapturingLogger<PasswordlessLinkedAccountSweepService> _logger = new();
+    private readonly List<string> _temporaryDirectories = new();
+
+    [Fact]
+    public void Constructor_ThrowsWhenAnyDependencyIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new PasswordlessLinkedAccountSweepService(null!, _crypto, _logger));
+        Assert.Throws<ArgumentNullException>(() => new PasswordlessLinkedAccountSweepService(_users, null!, _logger));
+        Assert.Throws<ArgumentNullException>(() => new PasswordlessLinkedAccountSweepService(_users, _crypto, null!));
+    }
+
+    [Fact]
+    public async Task StartAsync_WithoutLoadedPluginInstance_DoesNothing()
+    {
+        ResetPluginInstance();
+
+        var service = new PasswordlessLinkedAccountSweepService(_users, _crypto, _logger);
+
+        await service.StartAsync(CancellationToken.None);
+
+        _users.DidNotReceiveWithAnyArgs().GetUserById(Arg.Any<Guid>());
+        await _users.DidNotReceiveWithAnyArgs().UpdateUserAsync(Arg.Any<User>());
+        Assert.Empty(_logger.Entries);
+    }
+
+    [Fact]
+    public async Task StartAsync_SealsPasswordlessLinkedAccountsOfTheLoadedPlugin()
+    {
+        ResetPluginInstance();
+        var plugin = CreatePlugin();
+        try
+        {
+            var alice = TestModel.NewUser("alice");
+            TestModel.Link(plugin.Configuration, "oid", "keycloak", "alice", alice.Id);
+            _users.GetUserById(alice.Id).Returns(alice);
+
+            var service = new PasswordlessLinkedAccountSweepService(_users, _crypto, _logger);
+            await service.StartAsync(CancellationToken.None);
+
+            Assert.Equal(RecordingCryptoProvider.HashOf(_crypto.HashedPasswords[0]), alice.Password);
+            await _users.Received(1).UpdateUserAsync(alice);
+            Assert.Contains("Sealed 1 SSO-linked account(s)", Assert.Single(_logger.Entries));
+        }
+        finally
+        {
+            ResetPluginInstance();
+        }
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenTheSweepThrows_LogsAndDoesNotStopTheHost()
+    {
+        ResetPluginInstance();
+        var plugin = CreatePlugin();
+        try
+        {
+            var deadAccountId = Guid.NewGuid();
+            TestModel.Link(plugin.Configuration, "saml", "keycloak", "alice", deadAccountId);
+            _users
+                .When(userManager => userManager.GetUserById(deadAccountId))
+                .Throw(new InvalidOperationException("user store unreachable"));
+
+            var service = new PasswordlessLinkedAccountSweepService(_users, _crypto, _logger);
+
+            await service.StartAsync(CancellationToken.None);
+
+            var failure = Assert.Single(_logger.Entries);
+            Assert.Contains("[Error]", failure);
+            Assert.Contains("start-up sweep for password-less SSO-linked accounts failed; skipping", failure);
+        }
+        finally
+        {
+            ResetPluginInstance();
+        }
+    }
+
+    [Fact]
+    public void StopAsync_CompletesWithoutSideEffects()
+    {
+        var service = new PasswordlessLinkedAccountSweepService(_users, _crypto, _logger);
+
+        Assert.True(service.StopAsync(CancellationToken.None).IsCompletedSuccessfully);
+    }
+
+    /// <summary>
+    /// Creates the real plugin instance the service reads its links from. The configuration is lazy,
+    /// so a substituted serializer keeps it off the disk.
+    /// </summary>
+    /// <returns>A constructed plugin whose static <c>Instance</c> is now set.</returns>
+    private SSOPlugin CreatePlugin()
+    {
+        var temporaryDirectory = Path.Combine(Path.GetTempPath(), "sso-auth-sweep-tests-" + Guid.NewGuid().ToString("N"));
+        _temporaryDirectories.Add(temporaryDirectory);
+        Directory.CreateDirectory(temporaryDirectory);
+
+        var applicationPaths = Substitute.For<IApplicationPaths>();
+        applicationPaths.PluginsPath.Returns(temporaryDirectory);
+        applicationPaths.PluginConfigurationsPath.Returns(temporaryDirectory);
+
+        var serializer = Substitute.For<IXmlSerializer>();
+        serializer.DeserializeFromFile(Arg.Any<Type>(), Arg.Any<string>()).Returns(new PluginConfiguration());
+
+        return new SSOPlugin(applicationPaths, serializer);
+    }
+
+    private static void ResetPluginInstance()
+    {
+        typeof(SSOPlugin)
+            .GetProperty(nameof(SSOPlugin.Instance), BindingFlags.Public | BindingFlags.Static)!
+            .SetValue(null, null);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        // Reset the static instance even when a test failed before its own finally block.
+        ResetPluginInstance();
+
+        foreach (var directory in _temporaryDirectories)
+        {
+            try
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+            catch (Exception)
+            {
+                // Cleanup is best effort.
+            }
+        }
+    }
+}

--- a/SSO-Auth.Tests/Api/PasswordlessLinkedAccountSweepTests.cs
+++ b/SSO-Auth.Tests/Api/PasswordlessLinkedAccountSweepTests.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Library;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests.Api;
+
+public class PasswordlessLinkedAccountSweepTests
+{
+    private readonly IUserManager _users = Substitute.For<IUserManager>();
+    private readonly RecordingCryptoProvider _crypto = new();
+    private readonly CapturingLogger _logger = new();
+
+    [Fact]
+    public async Task SweepAsync_SealsPasswordlessLinkedAccountAndAuditsOnce()
+    {
+        var alice = TestModel.NewUser("alice");
+        var configuration = new PluginConfiguration();
+        TestModel.Link(configuration, "oid", "keycloak", "alice", alice.Id);
+        _users.GetUserById(alice.Id).Returns(alice);
+
+        var sealedCount = await new PasswordlessLinkedAccountSweep(configuration, _users, _crypto, _logger).SweepAsync();
+
+        Assert.Equal(1, sealedCount);
+        Assert.Equal(RecordingCryptoProvider.HashOf(_crypto.HashedPasswords[0]), alice.Password);
+        await _users.Received(1).UpdateUserAsync(alice);
+
+        var audit = Assert.Single(_logger.Entries);
+        Assert.Contains("[Warning]", audit);
+        Assert.Contains("[SSO Audit] Sealed 1 SSO-linked account(s) that had no stored password", audit);
+    }
+
+    [Fact]
+    public async Task SweepAsync_LeavesAccountThatAlreadyHoldsAPasswordAlone()
+    {
+        var alice = TestModel.NewUser("alice", "$PBKDF2$AB");
+        var configuration = new PluginConfiguration();
+        TestModel.Link(configuration, "oid", "keycloak", "alice", alice.Id);
+        _users.GetUserById(alice.Id).Returns(alice);
+
+        var sealedCount = await new PasswordlessLinkedAccountSweep(configuration, _users, _crypto, _logger).SweepAsync();
+
+        Assert.Equal(0, sealedCount);
+        Assert.Equal("$PBKDF2$AB", alice.Password);
+        await _users.DidNotReceiveWithAnyArgs().UpdateUserAsync(Arg.Any<User>());
+        Assert.Empty(_logger.Entries);
+    }
+
+    [Fact]
+    public async Task SweepAsync_TreatsEmptyStoredPasswordAsPasswordless()
+    {
+        var alice = TestModel.NewUser("alice", password: string.Empty);
+        var configuration = new PluginConfiguration();
+        TestModel.Link(configuration, "saml", "keycloak", "alice", alice.Id);
+        _users.GetUserById(alice.Id).Returns(alice);
+
+        var sealedCount = await new PasswordlessLinkedAccountSweep(configuration, _users, _crypto, _logger).SweepAsync();
+
+        Assert.Equal(1, sealedCount);
+        Assert.NotNull(alice.Password);
+    }
+
+    [Fact]
+    public async Task SweepAsync_LeavesLoginRoutingUntouched()
+    {
+        var alice = TestModel.NewUser("alice", provider: "Some.Custom.AuthenticationProvider");
+        var configuration = new PluginConfiguration();
+        TestModel.Link(configuration, "oid", "keycloak", "alice", alice.Id);
+        _users.GetUserById(alice.Id).Returns(alice);
+
+        await new PasswordlessLinkedAccountSweep(configuration, _users, _crypto, _logger).SweepAsync();
+
+        Assert.Equal("Some.Custom.AuthenticationProvider", alice.AuthenticationProviderId);
+    }
+
+    [Fact]
+    public async Task SweepAsync_SkipsLinkWhoseAccountNoLongerExists()
+    {
+        var configuration = new PluginConfiguration();
+        TestModel.Link(configuration, "oid", "keycloak", "alice", Guid.NewGuid());
+        _users.GetUserById(Arg.Any<Guid>()).Returns((User?)null);
+
+        var sealedCount = await new PasswordlessLinkedAccountSweep(configuration, _users, _crypto, _logger).SweepAsync();
+
+        Assert.Equal(0, sealedCount);
+        await _users.DidNotReceiveWithAnyArgs().UpdateUserAsync(Arg.Any<User>());
+        Assert.Empty(_logger.Entries);
+    }
+
+    [Fact]
+    public async Task SweepAsync_SealsEachDistinctAccountOnceAcrossProvidersAndModes()
+    {
+        var alice = TestModel.NewUser("alice");
+        var bob = TestModel.NewUser("bob");
+        var configuration = new PluginConfiguration();
+        TestModel.Link(configuration, "oid", "keycloak", "alice", alice.Id);
+        TestModel.Link(configuration, "saml", "keycloak", "alice@idp", alice.Id);
+        TestModel.Link(configuration, "oid", "authentik", "bob", bob.Id);
+        _users.GetUserById(alice.Id).Returns(alice);
+        _users.GetUserById(bob.Id).Returns(bob);
+
+        var sealedCount = await new PasswordlessLinkedAccountSweep(configuration, _users, _crypto, _logger).SweepAsync();
+
+        Assert.Equal(2, sealedCount);
+        await _users.Received(1).UpdateUserAsync(alice);
+        await _users.Received(1).UpdateUserAsync(bob);
+        Assert.Equal(2, _crypto.HashedPasswords.Count);
+        Assert.Contains("Sealed 2 SSO-linked account(s)", Assert.Single(_logger.Entries));
+    }
+
+    [Fact]
+    public async Task SweepAsync_IgnoresProvidersThatHoldNoLinks()
+    {
+        var configuration = new PluginConfiguration();
+        configuration.OidConfigs["keycloak"] = new OidConfig();
+
+        var sealedCount = await new PasswordlessLinkedAccountSweep(configuration, _users, _crypto, _logger).SweepAsync();
+
+        Assert.Equal(0, sealedCount);
+        _users.DidNotReceiveWithAnyArgs().GetUserById(Arg.Any<Guid>());
+    }
+
+    [Fact]
+    public async Task SweepAsync_IsIdempotentAcrossPasses()
+    {
+        var alice = TestModel.NewUser("alice");
+        var configuration = new PluginConfiguration();
+        TestModel.Link(configuration, "oid", "keycloak", "alice", alice.Id);
+        _users.GetUserById(alice.Id).Returns(alice);
+        var sweep = new PasswordlessLinkedAccountSweep(configuration, _users, _crypto, _logger);
+
+        var firstPass = await sweep.SweepAsync();
+        var secondPass = await sweep.SweepAsync();
+
+        Assert.Equal(1, firstPass);
+        Assert.Equal(0, secondPass);
+        await _users.Received(1).UpdateUserAsync(alice);
+        Assert.Single(_logger.Entries);
+    }
+
+    [Fact]
+    public void PasswordlessAccountsSealed_WhenWarningLevelIsDisabled_WritesNothing()
+    {
+        SsoAudit.PasswordlessAccountsSealed(new SilentLogger(), 3);
+    }
+
+    [Fact]
+    public void Constructor_ThrowsWhenAnyDependencyIsNull()
+    {
+        var configuration = new PluginConfiguration();
+
+        Assert.Throws<ArgumentNullException>(() => new PasswordlessLinkedAccountSweep(null!, _users, _crypto, _logger));
+        Assert.Throws<ArgumentNullException>(() => new PasswordlessLinkedAccountSweep(configuration, null!, _crypto, _logger));
+        Assert.Throws<ArgumentNullException>(() => new PasswordlessLinkedAccountSweep(configuration, _users, null!, _logger));
+        Assert.Throws<ArgumentNullException>(() => new PasswordlessLinkedAccountSweep(configuration, _users, _crypto, null!));
+    }
+}

--- a/SSO-Auth.Tests/Api/ProvisionedPasswordTests.cs
+++ b/SSO-Auth.Tests/Api/ProvisionedPasswordTests.cs
@@ -1,0 +1,50 @@
+using System;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using MediaBrowser.Model.Cryptography;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests.Api;
+
+public class ProvisionedPasswordTests
+{
+    [Fact]
+    public void Mint_ThrowsWhenCryptoProviderIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => ProvisionedPassword.Mint(null!));
+    }
+
+    [Fact]
+    public void Mint_ReturnsTheCryptoProvidersHashedString()
+    {
+        var crypto = new RecordingCryptoProvider();
+
+        var minted = ProvisionedPassword.Mint(crypto);
+
+        var hashedInput = Assert.Single(crypto.HashedPasswords);
+        Assert.Equal(RecordingCryptoProvider.HashOf(hashedInput), minted);
+    }
+
+    [Fact]
+    public void Mint_HashesSixtyFourBytesOfEntropy()
+    {
+        var crypto = new RecordingCryptoProvider();
+
+        ProvisionedPassword.Mint(crypto);
+
+        // 64 bytes of CSPRNG output encode to 88 base64 characters.
+        var hashedInput = Assert.Single(crypto.HashedPasswords);
+        Assert.Equal(64, Convert.FromBase64String(hashedInput).Length);
+    }
+
+    [Fact]
+    public void Mint_NeverRepeatsEntropy()
+    {
+        var crypto = new RecordingCryptoProvider();
+
+        ProvisionedPassword.Mint(crypto);
+        ProvisionedPassword.Mint(crypto);
+
+        Assert.Equal(2, crypto.HashedPasswords.Count);
+        Assert.NotEqual(crypto.HashedPasswords[0], crypto.HashedPasswords[1]);
+    }
+}

--- a/SSO-Auth.Tests/Api/TestDoubles.cs
+++ b/SSO-Auth.Tests/Api/TestDoubles.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Model.Cryptography;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests.Api;
+
+/// <summary>
+/// Captures every formatted log entry.
+/// </summary>
+internal sealed class CapturingLogger : ILogger
+{
+    private readonly List<string> _entries = new();
+
+    /// <summary>
+    /// Gets the captured entries, each prefixed with its level.
+    /// </summary>
+    public IReadOnlyList<string> Entries => _entries;
+
+    /// <inheritdoc />
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull => null;
+
+    /// <inheritdoc />
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    /// <inheritdoc />
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        _entries.Add($"[{logLevel}] {formatter(state, exception)}");
+    }
+}
+
+/// <summary>
+/// A category-typed wrapper around <see cref="CapturingLogger"/>.
+/// </summary>
+/// <typeparam name="T">The logger category.</typeparam>
+internal sealed class TypedCapturingLogger<T> : ILogger<T>
+{
+    private readonly CapturingLogger _inner = new();
+
+    /// <summary>
+    /// Gets the captured entries, each prefixed with its level.
+    /// </summary>
+    public IReadOnlyList<string> Entries => _inner.Entries;
+
+    /// <inheritdoc />
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull => _inner.BeginScope(state);
+
+    /// <inheritdoc />
+    public bool IsEnabled(LogLevel logLevel) => _inner.IsEnabled(logLevel);
+
+    /// <inheritdoc />
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        => _inner.Log(logLevel, eventId, state, exception, formatter);
+}
+
+/// <summary>
+/// A logger whose every level is disabled; <see cref="Log{TState}"/> throws, so a missed
+/// <c>IsEnabled</c> guard fails the test instead of silently asserting nothing.
+/// </summary>
+internal sealed class SilentLogger : ILogger
+{
+    /// <inheritdoc />
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull => null;
+
+    /// <inheritdoc />
+    public bool IsEnabled(LogLevel logLevel) => false;
+
+    /// <inheritdoc />
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        => throw new InvalidOperationException("Log was called although every level is disabled.");
+}
+
+/// <summary>
+/// Records every password handed to the hash function and answers with a hash deterministic on it.
+/// </summary>
+/// <remarks>
+/// Hand-rolled because <see cref="ICryptoProvider.CreatePasswordHash"/> takes a
+/// <c>ReadOnlySpan&lt;char&gt;</c>, which no mocking framework can intercept.
+/// </remarks>
+internal sealed class RecordingCryptoProvider : ICryptoProvider
+{
+    private readonly List<string> _hashedPasswords = new();
+
+    /// <summary>
+    /// Gets the plaintext passwords handed to the hash function, in call order.
+    /// </summary>
+    public IReadOnlyList<string> HashedPasswords => _hashedPasswords;
+
+    /// <inheritdoc />
+    public string DefaultHashMethod => "PBKDF2";
+
+    /// <summary>
+    /// Renders the persisted hash string this provider produces for a given plaintext password.
+    /// </summary>
+    /// <param name="password">The plaintext password that was hashed.</param>
+    /// <returns>The <c>User.Password</c> string for that password.</returns>
+    public static string HashOf(string password)
+        => new PasswordHash("PBKDF2", Encoding.UTF8.GetBytes(password)).ToString();
+
+    /// <inheritdoc />
+    public PasswordHash CreatePasswordHash(ReadOnlySpan<char> password)
+    {
+        var plaintext = password.ToString();
+        _hashedPasswords.Add(plaintext);
+
+        return new PasswordHash("PBKDF2", Encoding.UTF8.GetBytes(plaintext));
+    }
+
+    /// <inheritdoc />
+    public bool Verify(PasswordHash hash, ReadOnlySpan<char> password) => true;
+
+    /// <inheritdoc />
+    public byte[] GenerateSalt() => new byte[16];
+
+    /// <inheritdoc />
+    public byte[] GenerateSalt(int length) => new byte[length];
+}
+
+/// <summary>
+/// Builders for the entities and configuration the sweep tests use.
+/// </summary>
+internal static class TestModel
+{
+    /// <summary>The provider id Jellyfin's own user manager provisions accounts with.</summary>
+    public const string DefaultProvider = "Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider";
+
+    /// <summary>The password reset provider id Jellyfin's own user manager provisions accounts with.</summary>
+    public const string DefaultResetProvider = "Jellyfin.Server.Implementations.Users.DefaultPasswordResetProvider";
+
+    /// <summary>
+    /// Creates a Jellyfin user entity, optionally already holding a stored password.
+    /// </summary>
+    /// <param name="username">The account name.</param>
+    /// <param name="password">The stored password hash, or null when the account holds none.</param>
+    /// <param name="provider">The authentication provider the account is routed at.</param>
+    /// <returns>The user entity.</returns>
+    public static User NewUser(string username, string? password = null, string? provider = null)
+    {
+        var user = new User(username, provider ?? DefaultProvider, DefaultResetProvider);
+        user.Password = password;
+        return user;
+    }
+
+    /// <summary>
+    /// Adds a canonical link to a provider in the configuration, creating the provider entry if needed.
+    /// </summary>
+    /// <param name="configuration">The plugin configuration to add the link to.</param>
+    /// <param name="mode">The protocol, "oid" or "saml".</param>
+    /// <param name="provider">The provider name.</param>
+    /// <param name="canonicalName">The identity-provider side of the link.</param>
+    /// <param name="userId">The Jellyfin account the link points at.</param>
+    public static void Link(PluginConfiguration configuration, string mode, string provider, string canonicalName, Guid userId)
+    {
+        if (mode == "oid")
+        {
+            if (!configuration.OidConfigs.TryGetValue(provider, out var oidConfig))
+            {
+                oidConfig = new OidConfig();
+                configuration.OidConfigs[provider] = oidConfig;
+            }
+
+            var oidLinks = oidConfig.CanonicalLinks;
+            oidLinks[canonicalName] = userId;
+            oidConfig.CanonicalLinks = oidLinks;
+        }
+        else
+        {
+            if (!configuration.SamlConfigs.TryGetValue(provider, out var samlConfig))
+            {
+                samlConfig = new SamlConfig();
+                configuration.SamlConfigs[provider] = samlConfig;
+            }
+
+            var samlLinks = samlConfig.CanonicalLinks;
+            samlLinks[canonicalName] = userId;
+            samlConfig.CanonicalLinks = samlLinks;
+        }
+    }
+}

--- a/SSO-Auth.Tests/SSO-Auth.Tests.csproj
+++ b/SSO-Auth.Tests/SSO-Auth.Tests.csproj
@@ -10,8 +10,18 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
+  </ItemGroup>
+
+  <!-- The plugin excludes the Jellyfin runtime assets (the server provides them); a test host has no server. -->
+  <ItemGroup>
+    <PackageReference Include="Jellyfin.Common" Version="12.0.0" />
+    <PackageReference Include="Jellyfin.Controller" Version="12.0.0" />
+    <PackageReference Include="Jellyfin.Data" Version="12.0.0" />
+    <PackageReference Include="Jellyfin.Database.Implementations" Version="12.0.0" />
+    <PackageReference Include="Jellyfin.Model" Version="12.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SSO-Auth/Api/PasswordlessAccountSealer.cs
+++ b/SSO-Auth/Api/PasswordlessAccountSealer.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Cryptography;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Seals an account that holds no stored password by giving it an unguessable one, so the ordinary
+/// login form stops accepting the empty password for it.
+/// </summary>
+/// <remarks>
+/// Shared by the create arm, the login-time repair and the start-up sweep, so every writer seals an
+/// account the same way. The login routing is never touched and an existing password is kept.
+/// </remarks>
+internal static class PasswordlessAccountSealer
+{
+    /// <summary>
+    /// Seals the account if it holds no stored password.
+    /// </summary>
+    /// <param name="user">The account to seal.</param>
+    /// <param name="userManager">The user manager that persists the account.</param>
+    /// <param name="cryptoProvider">The crypto provider that hashes the sealed password.</param>
+    /// <returns>True when a password was minted and persisted; false when the account already had one.</returns>
+    internal static async Task<bool> SealAsync(User user, IUserManager userManager, ICryptoProvider cryptoProvider)
+    {
+        ArgumentNullException.ThrowIfNull(user);
+        ArgumentNullException.ThrowIfNull(userManager);
+        ArgumentNullException.ThrowIfNull(cryptoProvider);
+
+        // An empty stored password is the door; a real one an administrator set is left alone.
+        if (!string.IsNullOrEmpty(user.Password))
+        {
+            return false;
+        }
+
+        user.Password = ProvisionedPassword.Mint(cryptoProvider);
+        await userManager.UpdateUserAsync(user).ConfigureAwait(false);
+        return true;
+    }
+
+    /// <summary>
+    /// Seals a newly created account, removing it again if the write fails so the login fails closed.
+    /// </summary>
+    /// <param name="user">The account created by the current SSO flow.</param>
+    /// <param name="userManager">The user manager that persists the account.</param>
+    /// <param name="cryptoProvider">The crypto provider that hashes the sealed password.</param>
+    /// <param name="logger">The logger for a rollback that itself failed.</param>
+    /// <returns>A task that completes when the account is persisted.</returns>
+    internal static async Task SealNewAccountAsync(User user, IUserManager userManager, ICryptoProvider cryptoProvider, ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+
+        try
+        {
+            var sealedNow = await SealAsync(user, userManager, cryptoProvider).ConfigureAwait(false);
+            if (!sealedNow)
+            {
+                // The account already holds a password; only the login routing still needs persisting.
+                await userManager.UpdateUserAsync(user).ConfigureAwait(false);
+            }
+        }
+        catch (Exception)
+        {
+            // Remove the half-created account so the login fails closed rather than leave an enabled,
+            // unlinked account with no password behind.
+            try
+            {
+                await userManager.DeleteUserAsync(user.Id).ConfigureAwait(false);
+            }
+            catch (Exception deleteException)
+            {
+                // The account is stranded; naming it is what tells an administrator which one to repair.
+                logger.LogError(deleteException, "Could not remove SSO user {Username} after its password failed to persist; the account accepts an empty password until one is set.", user.Username);
+            }
+
+            throw;
+        }
+    }
+}

--- a/SSO-Auth/Api/PasswordlessLinkedAccountSweep.cs
+++ b/SSO-Auth/Api/PasswordlessLinkedAccountSweep.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Cryptography;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Seals every SSO-linked account that has no stored password by giving it an unguessable one, so
+/// the ordinary login form stops accepting the empty password for it.
+/// </summary>
+/// <remarks>
+/// The create arm only runs when an account is new, so accounts provisioned without a password, or
+/// password-less accounts an SSO identity was later linked to, keep that door open. The pass never
+/// touches <c>AuthenticationProviderId</c>, never overwrites an existing password, and is
+/// idempotent, so it can run on every boot.
+/// </remarks>
+internal sealed class PasswordlessLinkedAccountSweep
+{
+    private readonly PluginConfiguration _configuration;
+    private readonly IUserManager _userManager;
+    private readonly ICryptoProvider _cryptoProvider;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PasswordlessLinkedAccountSweep"/> class.
+    /// </summary>
+    /// <param name="configuration">The plugin configuration holding the canonical links.</param>
+    /// <param name="userManager">The user manager used to resolve and persist each account.</param>
+    /// <param name="cryptoProvider">The crypto provider that hashes the sealed password.</param>
+    /// <param name="logger">The logger the audit line is written to.</param>
+    internal PasswordlessLinkedAccountSweep(PluginConfiguration configuration, IUserManager userManager, ICryptoProvider cryptoProvider, ILogger logger)
+    {
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _userManager = userManager ?? throw new ArgumentNullException(nameof(userManager));
+        _cryptoProvider = cryptoProvider ?? throw new ArgumentNullException(nameof(cryptoProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Runs one pass and returns how many accounts it sealed.
+    /// </summary>
+    /// <returns>The number of accounts given a password by this pass.</returns>
+    internal async Task<int> SweepAsync()
+    {
+        var sealedAccounts = 0;
+
+        foreach (var userId in LinkedUserIds())
+        {
+            // A link can outlive its account; skip it rather than fail the whole pass.
+            if (_userManager.GetUserById(userId) is not { } user)
+            {
+                continue;
+            }
+
+            if (await PasswordlessAccountSealer.SealAsync(user, _userManager, _cryptoProvider).ConfigureAwait(false))
+            {
+                sealedAccounts++;
+            }
+        }
+
+        // One line for the whole pass, with a count only, and nothing when there was nothing to seal.
+        if (sealedAccounts > 0)
+        {
+            SsoAudit.PasswordlessAccountsSealed(_logger, sealedAccounts);
+        }
+
+        return sealedAccounts;
+    }
+
+    /// <summary>
+    /// Collects the distinct user ids every provider holds a canonical link for, across both protocols.
+    /// </summary>
+    /// <returns>The distinct user ids the canonical-link maps point at.</returns>
+    private IEnumerable<Guid> LinkedUserIds()
+    {
+        var linkedUserIds = new HashSet<Guid>();
+
+        if (_configuration.OidConfigs is not null)
+        {
+            foreach (var provider in _configuration.OidConfigs.Values)
+            {
+                AddLinkTargets(linkedUserIds, provider.CanonicalLinks);
+            }
+        }
+
+        if (_configuration.SamlConfigs is not null)
+        {
+            foreach (var provider in _configuration.SamlConfigs.Values)
+            {
+                AddLinkTargets(linkedUserIds, provider.CanonicalLinks);
+            }
+        }
+
+        return linkedUserIds;
+    }
+
+    /// <summary>
+    /// Adds the user ids one provider's link map points at. A provider with no links contributes nothing.
+    /// </summary>
+    /// <param name="linkedUserIds">The accumulating set of linked user ids.</param>
+    /// <param name="canonicalLinks">The provider's canonical-link map, or null when it has none.</param>
+    private static void AddLinkTargets(HashSet<Guid> linkedUserIds, SerializableDictionary<string, Guid> canonicalLinks)
+    {
+        if (canonicalLinks is null)
+        {
+            return;
+        }
+
+        foreach (var userId in canonicalLinks.Values)
+        {
+            linkedUserIds.Add(userId);
+        }
+    }
+}

--- a/SSO-Auth/Api/PasswordlessLinkedAccountSweepService.cs
+++ b/SSO-Auth/Api/PasswordlessLinkedAccountSweepService.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Cryptography;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Runs <see cref="PasswordlessLinkedAccountSweep"/> once at host start.
+/// </summary>
+/// <remarks>
+/// Any error is logged and swallowed: a repair that can stop the server from starting is worse
+/// than the hole it closes.
+/// </remarks>
+internal sealed class PasswordlessLinkedAccountSweepService : IHostedService
+{
+    private readonly IUserManager _userManager;
+    private readonly ICryptoProvider _cryptoProvider;
+    private readonly ILogger<PasswordlessLinkedAccountSweepService> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PasswordlessLinkedAccountSweepService"/> class.
+    /// </summary>
+    /// <param name="userManager">The user manager.</param>
+    /// <param name="cryptoProvider">The crypto provider that hashes the sealed password.</param>
+    /// <param name="logger">The logger.</param>
+    public PasswordlessLinkedAccountSweepService(IUserManager userManager, ICryptoProvider cryptoProvider, ILogger<PasswordlessLinkedAccountSweepService> logger)
+    {
+        _userManager = userManager ?? throw new ArgumentNullException(nameof(userManager));
+        _cryptoProvider = cryptoProvider ?? throw new ArgumentNullException(nameof(cryptoProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Runs the sweep at host start.
+    /// </summary>
+    /// <param name="cancellationToken">Unused; the pass is a bounded walk over the persisted link maps.</param>
+    /// <returns>A task that completes when the pass has finished.</returns>
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var plugin = SSOPlugin.Instance;
+        if (plugin is null)
+        {
+            // The plugin loads before host services start, so this is normally set; skip rather than throw.
+            return;
+        }
+
+        try
+        {
+            var sweep = new PasswordlessLinkedAccountSweep(plugin.Configuration, _userManager, _cryptoProvider, _logger);
+            await sweep.SweepAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // The empty-password door may still be open on those accounts; this line says so.
+            _logger.LogError(ex, "The start-up sweep for password-less SSO-linked accounts failed; skipping. Accounts provisioned by an old plugin version may still accept an empty password on the ordinary login form.");
+        }
+    }
+
+    /// <summary>
+    /// No-op on shutdown.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A completed task.</returns>
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/SSO-Auth/Api/ProvisionedPassword.cs
+++ b/SSO-Auth/Api/ProvisionedPassword.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Security.Cryptography;
+using MediaBrowser.Model.Cryptography;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Mints the unguessable password written to every account the plugin provisions, so the account
+/// cannot be signed into with the empty password on the ordinary login form.
+/// </summary>
+/// <remarks>
+/// The create arm in <see cref="SSOController"/> and the start-up sweep both mint through this
+/// method, so a swept account gets the same kind of secret as a fresh provisioning. The value is
+/// never displayed and never recoverable: nothing is meant to log in with it.
+/// </remarks>
+internal static class ProvisionedPassword
+{
+    // 64 bytes from the CSPRNG, base64-encoded, which is what the create arm has always minted.
+    // https://jonathancrozier.com/blog/how-to-generate-a-cryptographically-secure-random-string-in-dot-net-with-c-sharp
+    private const int EntropyBytes = 64;
+
+    /// <summary>
+    /// Mints one random password, already hashed in the form <c>User.Password</c> takes.
+    /// </summary>
+    /// <param name="cryptoProvider">Jellyfin's crypto provider, so the hash is produced the same way as a real password change.</param>
+    /// <returns>The hashed password, ready to assign to <c>User.Password</c>.</returns>
+    internal static string Mint(ICryptoProvider cryptoProvider)
+    {
+        ArgumentNullException.ThrowIfNull(cryptoProvider);
+
+        return cryptoProvider.CreatePasswordHash(Convert.ToBase64String(RandomNumberGenerator.GetBytes(EntropyBytes))).ToString();
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Mime;
 using System.Reflection;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Duende.IdentityModel.Client;
 using Duende.IdentityModel.OidcClient;
@@ -769,6 +768,12 @@ public class SSOController : ControllerBase
             _logger.LogInformation($"SSO user {canonicalName} doesn't exist, creating...");
             user = await _userManager.CreateUserAsync(canonicalName).ConfigureAwait(false);
 
+            // Route the account at this controller and seal it before anything else touches it: an
+            // account with no stored password accepts the empty one on the ordinary login form. If
+            // the write fails the account is deleted again, so the login fails closed.
+            user.AuthenticationProviderId = GetType().FullName;
+            await PasswordlessAccountSealer.SealNewAccountAsync(user, _userManager, _cryptoProvider, _logger);
+
             if (!enableAuthorization)
             {
                 var policy = _userManager.GetUserDto(user).Policy;
@@ -777,11 +782,6 @@ public class SSOController : ControllerBase
                 await _userManager.UpdatePolicyAsync(user.Id, policy).ConfigureAwait(false);
                 user = _userManager.GetUserById(user.Id);
             }
-
-            user.AuthenticationProviderId = GetType().FullName;
-            // https://jonathancrozier.com/blog/how-to-generate-a-cryptographically-secure-random-string-in-dot-net-with-c-sharp
-            user.Password = _cryptoProvider.CreatePasswordHash(Convert.ToBase64String(RandomNumberGenerator.GetBytes(64))).ToString();
-            await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
 
             // Make sure there aren't any trailing existing links
             var links = GetCanonicalLinks(mode, provider);
@@ -1148,6 +1148,13 @@ public class SSOController : ControllerBase
 
         // UpdatePolicyAsync refreshes the cached user entity; use the current instance below.
         user = _userManager.GetUserById(userId);
+
+        // A linked account may hold no stored password (adopted by name, or provisioned by a version
+        // that never persisted one); seal it at this login instead of waiting for the next start-up sweep.
+        if (await PasswordlessAccountSealer.SealAsync(user, _userManager, _cryptoProvider).ConfigureAwait(false))
+        {
+            SsoAudit.PasswordlessAccountSealedAtLogin(_logger);
+        }
 
         if (avatarUrl is not null)
         {

--- a/SSO-Auth/Api/SsoAudit.cs
+++ b/SSO-Auth/Api/SsoAudit.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Emits the plugin's audit-log entries. Every entry shares the "[SSO Audit]" prefix so operators
+/// can filter the trail, and no entry logs a secret or an account name.
+/// </summary>
+internal static class SsoAudit
+{
+    /// <summary>
+    /// Records the start-up sweep sealing SSO-linked accounts that had no stored password. Logged
+    /// with a count only, and only when something was actually sealed.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="sealedAccounts">How many accounts the sweep gave a password to.</param>
+    internal static void PasswordlessAccountsSealed(ILogger logger, int sealedAccounts)
+    {
+        if (!logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "[SSO Audit] Sealed {Count} SSO-linked account(s) that had no stored password: an account with none accepts the empty password on the ordinary login form, so these were reachable without the identity provider. Each was given an unguessable password that nothing knows and nothing can recover; their login provider routing was left exactly as it was. Any SSO-linked account that held no stored password is in this set, whatever plugin version created it.",
+            sealedAccounts);
+    }
+
+    /// <summary>
+    /// Records a linked account being sealed at login because it held no stored password. Logged
+    /// without the account name, like the sweep line: the account accepted the empty password on
+    /// the ordinary login form until this login.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    internal static void PasswordlessAccountSealedAtLogin(ILogger logger)
+    {
+        if (!logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "[SSO Audit] Sealed an SSO-linked account at login that had no stored password: an account with none accepts the empty password on the ordinary login form, so it was reachable without the identity provider until this login. It was given an unguessable password that nothing knows and nothing can recover; its login provider routing was left exactly as it was.");
+    }
+}

--- a/SSO-Auth/PluginServiceRegistrator.cs
+++ b/SSO-Auth/PluginServiceRegistrator.cs
@@ -1,0 +1,24 @@
+using Jellyfin.Plugin.SSO_Auth.Api;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Plugins;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Jellyfin.Plugin.SSO_Auth;
+
+/// <summary>
+/// Registers the plugin's host-side services with Jellyfin's DI container. Jellyfin discovers
+/// implementations in plugin assemblies through a parameterless constructor.
+/// </summary>
+public sealed class PluginServiceRegistrator : IPluginServiceRegistrator
+{
+    /// <summary>
+    /// Registers the plugin's services with the service collection.
+    /// </summary>
+    /// <param name="serviceCollection">The service collection.</param>
+    /// <param name="applicationHost">The server application host.</param>
+    public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
+    {
+        // Seals SSO-linked accounts without a stored password; the create arm only reaches new ones.
+        serviceCollection.AddHostedService<PasswordlessLinkedAccountSweepService>();
+    }
+}

--- a/SSO-Auth/SSO-Auth.csproj
+++ b/SSO-Auth/SSO-Auth.csproj
@@ -32,6 +32,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="SSO-Auth.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Duende.IdentityModel.OidcClient" Version="7.1.0" />
     <PackageReference Include="Jellyfin.Controller" Version="12.0.0">


### PR DESCRIPTION
Jellyfin accepts the **empty password** on the ordinary login form for any account that
has no stored password. The plugin's create arm has minted a random password for every
newly provisioned account since the 2022 , but that arm only ever runs when
an account is new, so linked accounts that were provisioned without a password, or
existing accounts an SSO identity was linked to by name or through the self-service
linking page, were left reachable without the identity provider: login form, username,
empty password, session.

## The three arms

**1. One mint, one sealer.** `ProvisionedPassword` is the single place a stored password is
invented (64 bytes from the OS CSPRNG, hashed through Jellyfin's own `ICryptoProvider`), and
`PasswordlessAccountSealer` is the single place the seal decision lives. All three writers below
go through them, so an account can never be sealed two different ways.

**2. Creation, fail-closed.** The provider routing and the sealed password are written on the
instance `CreateUserAsync` returned, immediately, before anything else touches the account. If
that write fails, the account is deleted again and the login fails, so no enabled, unlinked,
password-less account is ever left behind. (This also repairs the v5.0.0.0 defect: that release
minted the password but never persisted it, the `UpdateUserAsync` call landed only after the
tag, which is exactly the population the reporter hit.)

**3. A start-up sweep for the accounts the create arm never reaches.** A one-shot
`IHostedService` walks every canonical link of every provider (OID and SAML) and seals each
linked account with no stored password. It never touches `AuthenticationProviderId`, never
overwrites an existing password, is idempotent, and fail-safe (errors are logged, the server
still starts).

**4. A login-time repair.** During an SSO login, before the session is created, the same seal
runs, so an existing local account that only became SSO-linked at this login (signed in by
name) is closed immediately rather than at the next restart. thanks to 

## Operator-visible behaviour

    [SSO Audit] Sealed 1 SSO-linked account(s) that had no stored password: ...
    [SSO Audit] Sealed an SSO-linked account at login that had no stored password: ...


New test dependencies: `NSubstitute` for `IUserManager`; a hand-rolled crypto-provider
stub because `ICryptoProvider.CreatePasswordHash` takes a `ReadOnlySpan<char>` which no
mocking framework can intercept. The test project also references the Jellyfin packages
at runtime (the plugin excludes them because the server provides them; a test host has
no server).

Fixes #50. Thanks to @aslafy-z  with the login-time repair from the [pr](https://github.com/aslafy-z/jellyfin-plugin-sso/pull/1).
